### PR TITLE
Fix: Adjust Quotes Replacement for HTML Attributes with Spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,7 @@
 ## 5.0.1
 
 - Fix replacement of `&nbsp;` entries
+
+## 5.0.2
+
+— Fix quotes replacement for HTML attributes with spaces

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ru-typo",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ru-typo",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "WTFPL",
       "devDependencies": {
         "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ru-typo",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Russian typography script",
   "homepage": "https://github.com/Nufeen/typo#readme",
   "bugs": {

--- a/src/typo.ts
+++ b/src/typo.ts
@@ -88,10 +88,10 @@ const patterns: Record<
   ],
 
   quotes: [
-    [new RegExp('\\="(\\S*)"', "gmi"), "='$1'"], // prevents HTML attributes like href="https://github.com" from being broken
+    [new RegExp('\\="([^"]*)"', "gmi"), "='$1'"], // prevents HTML attributes like href="https://github.com" from being broken
     [new RegExp(`"(${any}|[0-9])`, "gmi"), `${openingQuote}$1`],
     [new RegExp(`"`, "gmi"), closingQuote],
-    [new RegExp("\\='(\\S*)'", "gmi"), '="$1"'], // prevents HTML attributes like href="https://github.com" from being broken
+    [new RegExp("\\='([^']*)'", "gmi"), '="$1"'], // prevents HTML attributes like href="https://github.com" from being broken
   ],
 };
 

--- a/test/typo.test.ts
+++ b/test/typo.test.ts
@@ -126,8 +126,15 @@ describe('Quotes', () => {
   })
 
   it('should preserve HTML attributes as is', () => {
-    const s1 = '<p>"Но об "одном" <a href="https://github.com" target="_blank">я не знал</a></p>'
-    const s2 = '<p>«Но об «одном» <a href="https://github.com" target="_blank">я не знал</a></p>'
+    const s1 = '<p>"Но об "одном" <a href="https://github.com" target="_blank" rel="nofollow">я не знал</a></p>'
+    const s2 = '<p>«Но об «одном» <a href="https://github.com" target="_blank" rel="nofollow">я не знал</a></p>'
+
+    typo(s1, { quotes: true }).should.equal(s2)
+  })
+
+  it('should preserve HTML attributes containing spaces as is', () => {
+    const s1 = '<p>"Но об "одном" <a class="comment first" href="https://github.com" target="_blank" rel="nofollow noopener norefferer">я не знал</a></p>'
+    const s2 = '<p>«Но об «одном» <a class="comment first" href="https://github.com" target="_blank" rel="nofollow noopener norefferer">я не знал</a></p>'
 
     typo(s1, { quotes: true }).should.equal(s2)
   })


### PR DESCRIPTION
This pull request addresses an issue in the `src/typo.ts` file where the quotes replacement logic needed adjustment to correctly handle HTML attributes containing spaces. This fix ensures that HTML attributes with spaces, such as `class="comment first"` or `rel="nofollow noopener noreferrer"`, are preserved as is during the quotes replacement process.